### PR TITLE
Hmf conjugates bugfix

### DIFF
--- a/lmfdb/hilbert_modular_forms/check_conjugates.py
+++ b/lmfdb/hilbert_modular_forms/check_conjugates.py
@@ -88,7 +88,9 @@ def fldlabel2conjdata(label):
     data['conjideals'] = cideals
     primes = niceideals(F, Fdata['primes'])
     data['primes'] = primes
+    primeslabels = [prm[2] for prm in primes]
     cprimes = conjideals(primes, auts)
+    cprimes = [[primeslabels.index(cprimes[(prm[2],ig)]) for prm in primes] for ig in range(len(auts))]
     data['conjprimes'] = cprimes
     return data
 


### PR DESCRIPTION
This should fix the issue with the field '6.6.905177.1'. You can now build the conjugate forms without adding them with checkadd_conj(fldlabel, buildform=True), which did not work in 08c7b4b202b40dbcdcdb3 but is fixed in the last commit.

Update: this updated pull-request contains the code having the correct behaviour for forms that are base-change but not from Q, and implements check_multiplicity_one
