### PR TITLE
Refix #698

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space_gamma1.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space_gamma1.py
@@ -87,6 +87,14 @@ def set_info_for_gamma1(level,weight,weight2=None):
             xi = r['cchi']
             orbit = r['character_orbit']
             k = r['weight']
+            d = r.get('d_newf',"n/a")
+            indb = r.get('in_wdb',0)
+            if d == 0:
+                indb = 1
+            if indb:
+                url = url_for('emf.render_elliptic_modular_forms', level=level, weight=k, character=xi)
+            else:
+                url = ''
             if not table['galois_orbits_reps'].has_key(xi):
                 table['galois_orbits_reps'][xi]={
                     'head' : "\(\chi_{{{0}}}({1},\cdot) \)".format(level,xi),  # yes, {{{ is required
@@ -101,20 +109,12 @@ def set_info_for_gamma1(level,weight,weight2=None):
                     # 'head' : "\({0}\)".format(xci),
                      'chi': "{0}".format(xci),
                  #    'url': url_for('characters.render_Dirichletwebpage', modulus=level, number=xci)
-                     'url': url_for('emf.render_elliptic_modular_forms', level=level, weight=k, character=xci)
+                     'url': url_for('emf.render_elliptic_modular_forms', level=level, weight=k, character=xci) if indb else ''
                     }
                     for xci in orbit]
             if len(orbit)>table['maxGalCount']:
                 table['maxGalCount']=len(orbit)
             table['cells'][xi]={}
-            d = r.get('d_newf',"n/a")
-            indb = r.get('in_wdb',0)
-            if d == 0:
-                indb = 1
-            if indb:
-                url = url_for('emf.render_elliptic_modular_forms', level=level, weight=k, character=xi)
-            else:
-                url = ''
             table['cells'][xi][k] ={'N': level, 'k': k, 'chi': xi, 'url': url, 'dim': d}
     table['galois_orbits_reps_numbers']=table['galois_orbits_reps'].keys()
     table['galois_orbits_reps_numbers'].sort()

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_render_web_modform_space_gamma1.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_render_web_modform_space_gamma1.html
@@ -174,6 +174,10 @@ $S_{ {{k}} }^{new}(\Gamma_0({{level}}), \chi)$</th>
 
 {% endif %}
 
+{% if debug %}
+  table:{{table}}
+{% endif %}
+
 
 
 {% endblock content %}

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_render_web_modform_space_gamma1.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_render_web_modform_space_gamma1.html
@@ -169,6 +169,7 @@ $S_{ {{k}} }^{new}(\Gamma_0({{level}}), \chi)$</th>
     {% endfor %}
   </tbody>
 </table>
+<small>The space is clickable whenever the Hecke orbits are stored for that space.</small>
 
 {% endif %}
 


### PR DESCRIPTION
The new display of Gamma_1 spaces did not use the same url as the old one, so #698 needed to be fixed again (not clickable if no data). Examples:
/ModularForm/GL2/Q/holomorphic/17/4/
(last character orbit)
