### PR TITLE
Check if cm_disc has been set to a valid value.

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_newform.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_newform.html
@@ -174,8 +174,7 @@ that preserve the character are shown in the table below.
     {% if not is_cm %}
     not a {{KNOWL('mf.elliptic.cm_form',title='CM form')}}.
     {% else %}
-    a {{KNOWL('mf.elliptic.cm_form',title='CM form')}}
-    with CM by {{ cm_field_knowl | safe }}.
+    a {{KNOWL('mf.elliptic.cm_form',title='CM form')}}{% if cm_disc < 0 %} with CM by {{ cm_field_knowl | safe }}{% endif %}.
     {% endif %}
     </li>
  {% endif %}


### PR DESCRIPTION
The method that sets the CM info currently fails sometimes because of
invalid data in the database, as it seems. I saw a few cases, e.g.
/ModularForm/GL2/Q/holomorphic/3/6/1/a/, where the information that this is
a CM form is corretly displayed but the CM field that is shown is
displayed as Q(\sqrt(0)). For now, I only check in the template that
the CM discriminant is a negative number.

This fixes lmfdb:#731
