### PR TITLE
only show coefficient field as related object if we have its url

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
@@ -143,9 +143,10 @@ def set_info_for_modular_form_space(level=None, weight=None, character=None, lab
     friends = list()
     for label in WMFS.hecke_orbits:
         f = WMFS.hecke_orbits[label]
-        if hasattr(f.base_ring, "lmfdb_label") and f.base_ring.lmfdb_label is not None:
+        # catch the url being None or set to '':
+        if hasattr(f.base_ring, "lmfdb_label") and f.base_ring.lmfdb_label:
             friends.append(('Number field ' + f.base_ring.lmfdb_pretty, f.base_ring.lmfdb_url))
-        if hasattr(f.coefficient_field, "lmfdb_label") and f.coefficient_field.lmfdb_label is not None:
+        if hasattr(f.coefficient_field, "lmfdb_url") and f.coefficient_field.lmfdb_url is not None:
             friends.append(('Number field ' + f.coefficient_field.lmfdb_pretty, f.coefficient_field.lmfdb_url))
     friends.append(("Dirichlet character \(" + WMFS.character.latex_name + "\)", WMFS.character.url()))
     friends = uniq(friends)


### PR DESCRIPTION
e.g. page ModularForm/GL2/Q/holomorphic/11/5/2/ which crashed because f.coefficient_field.lmfdb_url was not set.  I changed it so that it only gets added to the friends list if the url is set;  but there may be an underlying problem here -- why is the lmfdb_label set but not the lmfdb_url?
