### PR TITLE
Allow filtering knowls by category and quality

### DIFF
--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -555,18 +555,24 @@ def index():
 #        pass
 
     cur_cat = request.args.get("category", "")
-
     qualities = []
+
     defaults = "filtered" not in request.args
     filtermode = "filtered" in request.args
     searchmode = "search" in request.args
     categorymode = "category" in request.args
 
     from knowl import knowl_qualities
-    # TODO wrap this into a loop:
-    reviewed = request.form.get("reviewed", "") == "on" or defaults
-    ok = request.form.get("ok", "") == "on" or defaults
-    beta = request.form.get("beta", "") == "on" or defaults
+
+    if request.method == 'POST':
+        reviewed = request.form.get("reviewed", "") == "on" or defaults
+        ok = request.form.get("ok", "") == "on" or defaults
+        beta = request.form.get("beta", "") == "on" or defaults
+    if request.method == 'GET':
+        quals = list(request.args.getlist('qualities'))
+        reviewed = "reviewed" in quals
+        ok = "ok" in quals
+        beta = "beta" in quals
 
     if reviewed:
         qualities.append("reviewed")
@@ -634,4 +640,6 @@ def index():
                            filters=(beta, ok, reviewed),
                            categories = cats,
                            cur_cat = cur_cat,
-                           categorymode = categorymode)
+                           categorymode = categorymode,
+                           filtermode = filtermode,
+                           qualities = qualities)

--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -159,19 +159,19 @@ def ref_to_link(txt):
             the_doi = ref[3:]    # remove the "doi"
             this_link = '{{ LINK_EXT("' + the_doi + '","http://dx.doi.org/' + the_doi + '")| safe }}'
         elif ref.lower().startswith("mr"):
-            ref = ref.replace(":","") 
+            ref = ref.replace(":","")
             the_mr = ref[2:]    # remove the "MR"
             this_link = '{{ LINK_EXT("' + 'MR:' + the_mr + '", '
             this_link += '"http://www.ams.org/mathscinet/search/publdoc.html?pg1=MR&s1='
             this_link += the_mr + '") | safe}}'
         elif ref.lower().startswith("arxiv"):
-            ref = ref.replace(":","")  
+            ref = ref.replace(":","")
             the_arx = ref[5:]    # remove the "arXiv"
             this_link = '{{ LINK_EXT("' + 'arXiv:' + the_arx + '", '
             this_link += '"http://arxiv.org/abs/'
             this_link += the_arx + '")| safe}}'
 
-  
+
         if this_link:
             if ans:
                 ans += ", "
@@ -295,7 +295,7 @@ def test():
 @knowledge_page.route("/edit/<ID>")
 @login_required
 def edit(ID):
-    from pymongo.errors import OperationFailure 
+    from pymongo.errors import OperationFailure
     if not allowed_knowl_id.match(ID):
         flask.flash("""Oops, knowl id '%s' is not allowed.
                   It must consist of lowercase characters,
@@ -543,11 +543,11 @@ def cleanup():
     return "categories: %s <br/>reindexed %s knowls<br/>pruned %s histories" % (cats, q_knowls.count(), hcount)
 
 
-@knowledge_page.route("/")
+@knowledge_page.route("/", methods=['GET', 'POST'])
 def index():
     # bypassing the Knowl objects to speed things up
     from knowl import get_knowls
-# See issue #1169    
+# See issue #1169
 #    try:
 #        get_knowls().ensure_index('_keywords')
 #        get_knowls().ensure_index('cat')
@@ -557,16 +557,16 @@ def index():
     cur_cat = request.args.get("category", "")
 
     qualities = []
-    defaults = "filter" not in request.args
-    filtermode = "filter" in request.args
+    defaults = "filtered" not in request.args
+    filtermode = "filtered" in request.args
     searchmode = "search" in request.args
     categorymode = "category" in request.args
 
     from knowl import knowl_qualities
     # TODO wrap this into a loop:
-    reviewed = request.args.get("reviewed", "") == "on" or defaults
-    ok = request.args.get("ok", "") == "on" or defaults
-    beta = request.args.get("beta", "") == "on" or defaults
+    reviewed = request.form.get("reviewed", "") == "on" or defaults
+    ok = request.form.get("ok", "") == "on" or defaults
+    beta = request.form.get("beta", "") == "on" or defaults
 
     if reviewed:
         qualities.append("reviewed")

--- a/lmfdb/knowledge/templates/knowl-index.html
+++ b/lmfdb/knowledge/templates/knowl-index.html
@@ -50,10 +50,11 @@ $(function() {
  <td></td>
  <td>
   <form method="POST" action="{{ url_for('.index', category=cur_cat, filtered='True') }}">
-    Quality:
+    Quality:&nbsp;
     {% for kq in knowl_qualities -%}
+     <label for="{{ kq }}">{{ kq|capitalize }}</label>:
      <input type="checkbox" id="{{ kq }}" name="{{ kq }}" {% if filters[loop.index0] -%}checked{%- endif %} />
-        <label for="{{ kq }}">{{ kq|capitalize }}</label>
+     &nbsp;&nbsp;
     {%- endfor %}
     <button type="submit" name="filter">Filter</button>
    </form>

--- a/lmfdb/knowledge/templates/knowl-index.html
+++ b/lmfdb/knowledge/templates/knowl-index.html
@@ -19,7 +19,7 @@ $(function() {
 <table>
 <tr>
  <td>Search</td>
- <td> 
+ <td>
  <form id='knowl-search' action="{{ url_for('.index') }}" method="GET">
     <input name="search" value="{{ search }}" size="40" placeholder="ID, description, #hashtag, or full text"/>
     {% if search|length > 0 -%}<a href="{{url_for('.index')}}">clear</a>{%- endif %}
@@ -30,11 +30,11 @@ $(function() {
 
 <tr>
  <td>Filter</td>
- <td>Category: 
+ <td>Category:
     {% for cat in categories -%}
-     <a 
+     <a
       {% if cur_cat == cat -%}class='curcat'{%- endif %}
-      href="{{ url_for('.index', category=cat) }}">{{cat}}</a>
+      href="{{ url_for('.index', qualities=qualities, category=cat,) }}">{{cat}}</a>
        {# {% if not loop.last -%} &middot; {%- endif %} #}
     {%- endfor %}
     {% if categorymode -%}
@@ -68,7 +68,7 @@ $(function() {
 
 <tr>
  <td>More</td>
- <td> 
+ <td>
    <a href="{{ url_for('.history') }}">Recently modified Knowls</a></td>
 </tr>
 </table>

--- a/lmfdb/knowledge/templates/knowl-index.html
+++ b/lmfdb/knowledge/templates/knowl-index.html
@@ -49,7 +49,11 @@ $(function() {
 <tr>
  <td></td>
  <td>
-  <form method="POST" action="{{ url_for('.index', category=cur_cat, filtered='True') }}">
+ {% if categorymode %}
+   <form method="POST" action="{{ url_for('.index', category=cur_cat, filtered='True') }}">
+ {% else %}
+   <form method="POST" action="{{ url_for('.index', filtered='True') }}">
+ {% endif %}
     Quality:&nbsp;
     {% for kq in knowl_qualities -%}
      <label for="{{ kq }}">{{ kq|capitalize }}</label>:

--- a/lmfdb/knowledge/templates/knowl-index.html
+++ b/lmfdb/knowledge/templates/knowl-index.html
@@ -34,7 +34,7 @@ $(function() {
     {% for cat in categories -%}
      <a 
       {% if cur_cat == cat -%}class='curcat'{%- endif %}
-      href="{{ url_for('.index', category = cat) }}">{{cat}}</a>
+      href="{{ url_for('.index', category=cat) }}">{{cat}}</a>
        {# {% if not loop.last -%} &middot; {%- endif %} #}
     {%- endfor %}
     {% if categorymode -%}
@@ -45,11 +45,11 @@ $(function() {
  </td>
 </tr>
 
-{% if not searchmode and not categorymode %}
+{% if not searchmode %}
 <tr>
  <td></td>
  <td>
-  <form method="GET" action="{{ url_for('.index') }}">
+  <form method="POST" action="{{ url_for('.index', category=cur_cat, filtered='True') }}">
     Quality:
     {% for kq in knowl_qualities -%}
      <input type="checkbox" id="{{ kq }}" name="{{ kq }}" {% if filters[loop.index0] -%}checked{%- endif %} />


### PR DESCRIPTION
This makes it possible to click on a category in /knowledge/, and then choose some subset of qualities and filter them out. It does *not* allow the other direction (unfortunately), and I struggled to find a reasonable way to allow one to maintain filters when clicknig on another category. It is possible if I were to do a larger rewrite, or if I were to mix GET and POST requests beyond what I think is reasonable.

What do you think?